### PR TITLE
Treeningu järgsed kiired parandused

### DIFF
--- a/abc_est/6/readme.md
+++ b/abc_est/6/readme.md
@@ -93,6 +93,8 @@ Avame MariaDB konsooli:
 mysql -u root -p mydb
 ```
 
+NB! Parooliks on see väärtus, mida me varasemalt saladuste kaudu määrasime. 
+
 Ning uurime kas konfiguratsiooni kaardil seadistatud muutujad on korrektselt arvesse võetud: 
 
 ```

--- a/abc_est/7/readme.md
+++ b/abc_est/7/readme.md
@@ -48,10 +48,12 @@ Käivitage **liveandready** teenus ja deployment.
 k create -f liveandready.yaml
 ```
 
-Käivitage jälgimise skript:
+Andke skriptidele kävitamise õigused ning käivitage jälgimise skript, pannes selle argumendiks oma varasemalt loodud nimeruumi väärtuse (eesnimi-perenimi):
 
 ```
-./monitor.sh
+chmod u+x monitor.sh
+chmod u+x how_many_pods.sh
+./monitor.sh namespace
 ```
 
 Jälgige, kuidas jooksvate Pod'ide olukord muutub. 


### PR DESCRIPTION
Treeningu teksti jäid mõned vead sisse, mis tulid treeningu käigus välja. Viimases ülesandes oli puudu faili õiguste seadmine ning skippti argumendi määramine. 